### PR TITLE
Type-check expectation arguments when precept is disabled

### DIFF
--- a/src/macros_stubs.rs
+++ b/src/macros_stubs.rs
@@ -1,59 +1,155 @@
-// This file must be kept in sync with macros.rs
+// This file must be kept in sync with macros.rs.
+//
+// When the `enabled` feature is off these macros register no catalog entries
+// and perform no dispatch — precept compiles away to nothing. But "nothing"
+// must not mean "discard the arguments": the condition and details expressions
+// still have to be **type-checked**, and every temporary they reference has to
+// count as **used**, so that
+//
+//   1. the same source compiles identically with and without `enabled` (a typo
+//      or type error in an expectation is caught in every build, not just the
+//      instrumented one — the guarantee that makes `observe!` blocks safe to
+//      leave inline), and
+//   2. a temporary that exists only to feed an expectation does not trip
+//      `unused_variables` / `unused_assignments` in a downstream crate built
+//      with `-D warnings`.
+//
+// Each expansion therefore places its arguments inside `if false { … }`. That
+// block is fully type- and borrow-checked (dead code is still checked), the
+// contained expressions mark their captures as used, and the branch is provably
+// unreachable so it is eliminated before codegen — keeping the crate's
+// zero-runtime-overhead promise: the arguments are never evaluated at runtime.
+//
+// `$condition` and `json!($details)` are consumed by value to mirror exactly how
+// the enabled path in macros.rs evaluates them (same moves, same borrows).
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! define_entry {
-    ($($ignore:tt)*) => {};
+    ($expectation:expr, $property:expr) => {
+        if false {
+            let _ = $expectation;
+            let _ = &$property;
+        }
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! emit_entry {
-    ($($ignore:tt)*) => {};
+    ($entry:expr, $condition:expr) => {
+        if false {
+            let _ = $entry;
+            let _ = $condition;
+        }
+    };
+    ($entry:expr, $condition:expr, $($details:tt)+) => {
+        if false {
+            let _ = $entry;
+            let _ = $condition;
+            let _ = $crate::deps::serde_json::json!($($details)+);
+        }
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! define_and_emit_entry {
-    ($($ignore:tt)*) => {};
+    ($expectation:expr, $property:expr, $condition:expr) => {
+        if false {
+            let _ = $expectation;
+            let _ = &$property;
+            let _ = $condition;
+        }
+    };
+    ($expectation:expr, $property:expr, $condition:expr, $($details:tt)+) => {
+        if false {
+            let _ = $expectation;
+            let _ = &$property;
+            let _ = $condition;
+            let _ = $crate::deps::serde_json::json!($($details)+);
+        }
+    };
 }
 
 #[macro_export]
 macro_rules! emit_event {
-    ($($ignore:tt)*) => {};
+    ($name:expr, $($details:tt)+) => {
+        if false {
+            let _ = &$name;
+            let _ = $crate::deps::serde_json::json!($($details)+);
+        }
+    };
 }
 
 #[macro_export]
 macro_rules! setup_complete {
-    ($($ignore:tt)*) => {};
+    () => {};
+    ($($details:tt)+) => {
+        if false {
+            let _ = $crate::deps::serde_json::json!($($details)+);
+        }
+    };
 }
 
 #[macro_export]
 macro_rules! expect_always {
-    ($($ignore:tt)*) => {};
+    ($condition:expr, $property:expr$(, $($details:tt)+)?) => {
+        $crate::define_and_emit_entry!(
+            (), $property, $condition $(, $($details)+)?
+        )
+    };
 }
 
 #[macro_export]
 macro_rules! expect_always_or_unreachable {
-    ($($ignore:tt)*) => {};
+    ($condition:expr, $property:expr$(, $($details:tt)+)?) => {
+        $crate::define_and_emit_entry!(
+            (), $property, $condition $(, $($details)+)?
+        )
+    };
 }
 
 #[macro_export]
 macro_rules! expect_sometimes {
-    ($($ignore:tt)*) => {};
+    ($condition:expr, $property:expr$(, $($details:tt)+)?) => {
+        $crate::define_and_emit_entry!(
+            (), $property, $condition $(, $($details)+)?
+        )
+    };
 }
 
 #[macro_export]
 macro_rules! expect_reachable {
-    ($($ignore:tt)*) => {};
+    ($property:expr$(, $($details:tt)+)?) => {
+        $crate::define_and_emit_entry!(
+            (), $property, true $(, $($details)+)?
+        )
+    };
 }
 
 #[macro_export]
 macro_rules! expect_unreachable {
-    ($($ignore:tt)*) => {};
+    ($property:expr$(, $($details:tt)+)?) => {
+        $crate::define_and_emit_entry!(
+            (), $property, false $(, $($details)+)?
+        )
+    };
 }
 
 #[macro_export]
 macro_rules! sometimes_fault {
-    ($($ignore:tt)*) => {};
+    ($name:expr, $fault:expr) => {
+        if false {
+            let _ = &$name;
+            let _ = $fault;
+        }
+    };
+    ($name:expr, $fault:expr, $($details:tt)+) => {
+        if false {
+            let _ = &$name;
+            let _ = $fault;
+            let _ = $crate::deps::serde_json::json!($($details)+);
+        }
+    };
 }


### PR DESCRIPTION
## Problem

When the `enabled` feature is off, every macro in `macros_stubs.rs` expands to `{}`, discarding its condition and details expressions entirely. That has two consequences:

1. **Arguments aren't type-checked in the disabled build.** A typo or type error inside an `expect_*!` / `observe!` block only surfaces when the crate is compiled *with* `enabled`. This defeats the "same source compiles identically in every configuration" guarantee that makes `observe!` blocks safe to leave inline in the system under test.

2. **Temporaries that exist only to feed an expectation become unused.** In a downstream crate built with `-D warnings`, a perfectly ordinary pattern warns (and fails CI):

   ```rust
   observe!(|| {
       let sum: u64 = inputs.iter().sum();          // only used by the assertion
       expect_always!(sum == expected, "conserved", { "sum": sum });
   });
   ```

   With `enabled` off, `expect_always!` vanishes and `sum` is now `unused_variables` / `unused_assignments`.

## Fix

Rewrite each disabled stub to reference its arguments inside a dead `if false { … }` block:

```rust
macro_rules! define_and_emit_entry {
    ($expectation:expr, $property:expr, $condition:expr $(, $($details:tt)+)?) => {
        if false {
            let _ = $expectation;
            let _ = &$property;
            let _ = $condition;
            $( let _ = $crate::deps::serde_json::json!($($details)+); )?
        }
    };
}
```

`if false { … }` is exactly the right tool here:

- **Zero runtime overhead** — the branch is provably unreachable and eliminated before codegen, so the arguments are never evaluated at runtime. The crate's "0 runtime overhead when disabled" promise is preserved.
- **Still fully type- and borrow-checked** — dead code is still checked, so a type error in an expectation now fails to compile in *every* configuration.
- **Marks captures as used** — `let _ = $condition` / `json!($details)` reference every temporary, silencing both `unused_variables` and the liveness `assigned…never read` lints.

Argument evaluation mirrors the enabled path in `macros.rs` (by value, same moves/borrows), so anything that compiles with `enabled` also compiles without it.

Only `macros_stubs.rs` changes; the enabled path (`macros.rs`) is untouched.

## Verification

- `cargo test` passes with and without `enabled`.
- `cargo clippy --all-targets -- -D warnings` clean with and without `enabled` (modulo a pre-existing `fault.rs` `assertions_on_constants` lint unrelated to this change).
- A type error inside a disabled `expect_always!` still fails to compile (`E0277`).
- A downstream crate whose `observe!` block has an assertion-only temporary no longer warns under `-D warnings`, in both feature configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
